### PR TITLE
packge: fix build

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/nixberg/endianbytes-swift",
         "state": {
           "branch": null,
-          "revision": "c2070dbf074c22e147d074e33a289ba228db0a28",
-          "version": "0.3.0"
+          "revision": "c58c2275ba94c50de2573c5a1df3f5ceb2089cb4",
+          "version": "0.5.1"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -10,6 +10,7 @@ let package = Package(
             targets: ["BLAKE3"]),
     ],
     dependencies: [
+        .package(url: "https://github.com/apple/swift-algorithms", from: "1.0.0"),
         .package(url: "https://github.com/nixberg/crypto-traits-swift", from: "0.2.1"),
         .package(url: "https://github.com/nixberg/endianbytes-swift", from: "0.4.0"),
         .package(url: "https://github.com/nixberg/hexstring-swift", from: "0.2.0"),
@@ -18,8 +19,9 @@ let package = Package(
         .target(
             name: "BLAKE3",
             dependencies: [
+                .product(name: "Algorithms", package: "swift-algorithms"),
                 .product(name: "Duplex", package: "crypto-traits-swift"),
-                .product(name: "EndianBytes", package: "endianbytes-swift"),
+                .product(name: "SIMDEndianBytes", package: "endianbytes-swift"),
             ]),
         .testTarget(
             name: "BLAKE3Tests",

--- a/Sources/BLAKE3/TheOutput.swift
+++ b/Sources/BLAKE3/TheOutput.swift
@@ -1,5 +1,5 @@
 import Algorithms
-import EndianBytes
+import SIMDEndianBytes
 
 struct TheOutput {
     private let inputChainingValue: KeyWords


### PR DESCRIPTION
 1. Add explicit dependency on swift-algorithms

    Something must have changed recently and swiftpm no longer exposes transitive dependencies to target srouce files when compiling.

2.  Import SIMDEndianBytes instead of EndianBytes.

    The required extension is part of that module now.